### PR TITLE
Solve ktestGenerator illegal heap deallocation

### DIFF
--- a/src/KTestGenerator.cpp
+++ b/src/KTestGenerator.cpp
@@ -139,9 +139,6 @@ namespace
 		/* Fill KTestObjects for arguments */
 		for(auto& arg : GetFunctionArgumentList(backgroundFunc))
 		{
-			if(arg.hasStructRetAttr())
-				continue;
-
 			std::string argName = GetArgumentName(&M, &arg);
 
 			/* Copy the argument-name into the obj */


### PR DESCRIPTION
removed the iteration skip that causes a mismatch between the number of allocated objects and the real number of objects